### PR TITLE
Improve PDF generation stability

### DIFF
--- a/composeToPdf/src/main/java/com/jksalcedo/app/PdfImageMonitor.kt
+++ b/composeToPdf/src/main/java/com/jksalcedo/app/PdfImageMonitor.kt
@@ -21,10 +21,12 @@
 */
 package com.jksalcedo.app
 
-import kotlinx.coroutines.delay
+import android.view.View
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.resume
 
 class PdfImageMonitor {
     private val loadingCount = AtomicInteger(0)
@@ -42,11 +44,17 @@ class PdfImageMonitor {
         }
     }
 
-    suspend fun waitForImages() {
-        // Wait until the flow is true
+    suspend fun waitForImages(view: View) {
+        // Wait until all images have finished loading
         isIdle.first { it }
 
-        // Extra delay to ensure rendering completes
-        delay(200)
+        // Wait for the next frame to ensure images are rendered into the view
+        waitForNextFrame(view)
+    }
+
+    private suspend fun waitForNextFrame(view: View) = suspendCancellableCoroutine { continuation ->
+        view.post {
+            continuation.resume(Unit)
+        }
     }
 }


### PR DESCRIPTION
Replaced `delay()` calls with more reliable coroutine-based waits to ensure content, including images, is fully rendered before generating the PDF.

- Implemented `waitForNextFrame` and `waitForDrawReady` using `suspendCancellableCoroutine` to wait for the view to be properly measured, laid out, and drawn.
- Updated `PdfImageMonitor` to wait for the next frame after all images are loaded, ensuring they are rendered in the view.