### PR TITLE
Improve scaling and orientation handling

### DIFF
--- a/app/src/main/java/com/jksalcedo/app/MainActivity.kt
+++ b/app/src/main/java/com/jksalcedo/app/MainActivity.kt
@@ -80,7 +80,26 @@ fun Layout(context: Context, content: TextFieldState) {
                                 val outputStream = FileOutputStream(file)
                                 val result = pdfGenerator.generate(
                                     outputStream = outputStream,
-                                    pageSize = PdfPageSize.A4(100),
+                                    pageSize = PdfPageSize.A4(72)
+                                        .orientation(Orientation.LANDSCAPE),
+                                    pages = listOf({
+                                        Text(
+                                            text = content.text.toString()
+                                        )
+                                    }, {
+                                        PdfAsyncImage(
+                                            model = "https://www.pixelstalk.net/wp-content/uploads/2016/06/HD-images-of-nature-download.jpg",
+                                            contentDescription = ""
+                                        )
+                                    }
+                                    )
+                                )
+                                val file2 = File(it, "test2.pdf")
+                                val outputStream2 = FileOutputStream(file2)
+                                pdfGenerator.generate(
+                                    outputStream = outputStream2,
+                                    pageSize = PdfPageSize.A4(200)
+                                        .orientation(Orientation.LANDSCAPE),
                                     pages = listOf({
                                         Text(
                                             text = content.text.toString()

--- a/composeToPdf/src/main/java/com/jksalcedo/app/PdfGenerator.kt
+++ b/composeToPdf/src/main/java/com/jksalcedo/app/PdfGenerator.kt
@@ -87,8 +87,8 @@ class PdfGenerator(private val context: Context) {
                                     Box(
                                         modifier = Modifier
                                             .size(
-                                                pageSize.width.toDp(),
-                                                pageSize.height.toDp()
+                                                pageSize.width.toDp(pageSize.dpi),
+                                                pageSize.height.toDp(pageSize.dpi)
                                             )
                                             .onGloballyPositioned {
                                                 if (!contentReady.isCompleted) {
@@ -164,9 +164,10 @@ class PdfGenerator(private val context: Context) {
         }
     }
 
-    private fun Int.toDp(): Dp {
-        val density = context.resources.displayMetrics.density
-        return (this / density).dp
+    private fun Int.toDp(dpi: Int): Dp {
+        // 160 is the baseline dpi of Android
+        val scaleFactor = dpi / 160f
+        return (this / scaleFactor).dp
     }
 
     private suspend fun waitForNextFrame(view: View) = suspendCancellableCoroutine { continuation ->

--- a/composeToPdf/src/main/java/com/jksalcedo/app/PdfPageSize.kt
+++ b/composeToPdf/src/main/java/com/jksalcedo/app/PdfPageSize.kt
@@ -21,14 +21,39 @@
 */
 package com.jksalcedo.app
 
-data class PdfPageSize(val width: Int, val height: Int, val dpi: Int) {
+data class PdfPageSize(val width: Int, val height: Int, val dpi: Int = 72) {
+
+    fun orientation(orientation: Orientation): PdfPageSize {
+        return when (orientation) {
+            Orientation.PORTRAIT -> {
+                if (width > height) {
+                    PdfPageSize(width = height, height = width, dpi = dpi)
+                } else {
+                    this
+                }
+            }
+
+            Orientation.LANDSCAPE -> {
+                if (width < height) {
+                    PdfPageSize(width = height, height = width, dpi = dpi)
+                } else {
+                    this
+                }
+            }
+        }
+    }
+
     companion object {
 
         // A4: 8.27 x 11.69 inches
         fun A4(dpi: Int = 72) = PdfPageSize((8.27 * dpi).toInt(), (11.69 * dpi).toInt(), dpi)
 
         // US Letter: 8.5 x 11 inches
-        fun Letter(dpi: Int = 72) = PdfPageSize((8.5 * dpi).toInt(), (11 * dpi), dpi)
+        fun Letter(dpi: Int = 72) = PdfPageSize((8.5 * dpi).toInt(), (11.0 * dpi).toInt(), dpi)
 
     }
+}
+
+enum class Orientation {
+    PORTRAIT, LANDSCAPE
 }


### PR DESCRIPTION
This commit introduces several enhancements to the PDF generation logic:

-   **`PdfPageSize.kt`**:
    -   Adds an `orientation` function to easily switch between `PORTRAIT` and `LANDSCAPE`.
    -   Sets a default DPI of 72.
    -   Introduces the `Orientation` enum.

-   **`PdfGenerator.kt`**:
    -   Refactors the `Int.toDp()` extension function to correctly calculate density based on the provided page DPI instead of the device's screen density. This ensures proper scaling of Composables on the PDF canvas.

-   **`MainActivity.kt`**:
    -   Updates the example usage to demonstrate the new orientation feature and multi-page generation.